### PR TITLE
Cherry picking enable mDNS discovery for mpc

### DIFF
--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include "lib/dnssd/Resolver.h"
 #include <controller/CHIPCommissionableNodeController.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/UnitTestRegistration.h>
@@ -43,7 +44,10 @@ public:
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
+
     CHIP_ERROR StopDiscovery(DiscoveryContext &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter, DiscoveryContext &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -51,11 +51,14 @@ public:
 
     // Members that implement Resolver interface.
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
+
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) override;
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter, DiscoveryContext & context) override;
     CHIP_ERROR StopDiscovery(DiscoveryContext & context) override;
+
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
     static DiscoveryImplPlatform & GetInstance();

--- a/src/lib/dnssd/ResolverProxy.cpp
+++ b/src/lib/dnssd/ResolverProxy.cpp
@@ -26,7 +26,10 @@ CHIP_ERROR ResolverProxy::Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEnd
 {
     VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    ReturnErrorOnFailure(mResolver.Init(udpEndPoint));
+    if (!mResolver.IsInitialized())
+    {
+        ReturnErrorOnFailure(mResolver.Init(udpEndPoint));
+    }
     mContext = Platform::New<DiscoveryContext>();
     VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_NO_MEMORY);
 
@@ -53,6 +56,13 @@ CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
     VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     return mResolver.DiscoverCommissioners(filter, *mContext);
+}
+
+CHIP_ERROR ResolverProxy::DiscoverOperational(DiscoveryFilter filter)
+{
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    return mResolver.DiscoverOperational(filter, *mContext);
 }
 
 CHIP_ERROR ResolverProxy::StopDiscovery()

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -52,8 +52,17 @@ public:
         }
     }
 
+    void SetOperationalBrowseDelegate(OperationalBrowseDelegate * delegate)
+    {
+        if (mContext != nullptr)
+        {
+            mContext->SetOperationalBrowseDelegate(delegate);
+        }
+    }
+
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter());
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter());
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter = DiscoveryFilter());
     CHIP_ERROR StopDiscovery();
 
 private:

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -44,11 +44,17 @@ public:
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
+
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter, DiscoveryContext & context) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
     CHIP_ERROR StopDiscovery(DiscoveryContext & context) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -228,6 +228,21 @@ CHIP_ERROR BrowseCommissionerHandler(int argc, char ** argv)
     return sResolverProxy.DiscoverCommissioners(filter);
 }
 
+CHIP_ERROR BrowseOpertionalHandler(int argc, char ** argv)
+{
+    Dnssd::DiscoveryFilter filter;
+
+    if (!ParseSubType(argc, argv, filter))
+    {
+        streamer_printf(streamer_get(), "Invalid argument\r\n");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    streamer_printf(streamer_get(), "Browsing operational nodes...\r\n");
+
+    return sResolverProxy.DiscoverOperational(filter);
+}
+
 CHIP_ERROR BrowseHandler(int argc, char ** argv)
 {
     if (argc == 0)
@@ -262,6 +277,9 @@ void RegisterDnsCommands()
           "Browse Matter commissionable nodes. Usage: dns browse commissionable [subtype]" },
         { &BrowseCommissionerHandler, "commissioner",
           "Browse Matter commissioner nodes. Usage: dns browse commissioner [subtype]" },
+        { &BrowseOpertionalHandler, "operational",
+          "Browse Matter all operationional nodes. Usage: dns browse operational [subtype]" },
+
     };
 
     static const shell_command_t sDnsSubCommands[] = {


### PR DESCRIPTION
Description:

This adds changes intermediate changes required for mDNS node discovery for MPC, until mDNS commits from CSA fork is cherry-picked here.


